### PR TITLE
Ajustes practica MR

### DIFF
--- a/_posts/2017-08-26-practica-mr.md
+++ b/_posts/2017-08-26-practica-mr.md
@@ -87,7 +87,7 @@ PASAJERO   (<u><b>tipoDoc</b></u>, <b>nroDoc</b>, nombre, apellido)
 TIPO_DOC   (<b>tipoDoc</b>, descTipoDoc)
 UBICACIÓN  (<b>nroAsiento</b>, <b>fila</b>, <u>idClase</u>, <b><u>idAvion</u></b>)
 CLASE      (<b>idClase</b>, descClase)
-TARIFA     (<b><u>codAeptoOrigen</u></b>, <b><u>codAeptoDestino</u></b>, precioClaseTurista, <u>fechaDesde</u>, fechaHasta)
+TARIFA     (<b><u>codAeptoOrigen</u></b>, <b><u>codAeptoDestino</u></b>, precioClaseTurista, <b>fechaDesde</b>, fechaHasta)
 PASAJE     (<b><u>tipoDoc</u></b>, <b><u>nroDoc</u></b>, <b><u>nroVuelo</u></b>, <u>nroAsiento</u>, <u>fila</u>)
 </pre>
 

--- a/_posts/2017-08-26-practica-mr.md
+++ b/_posts/2017-08-26-practica-mr.md
@@ -85,7 +85,7 @@ VUELO      (<b>nroVuelo</b>, fecha_salida, <u>codAeptoOrigen</u>, <u>codAeptoDes
 AEROPUERTO (<b>codAepto</b>, nombreaepto)
 PASAJERO   (<u><b>tipoDoc</b></u>, <b>nroDoc</b>, nombre, apellido)
 TIPO_DOC   (<b>tipoDoc</b>, descTipoDoc)
-UBICACIÓN  (<b>nroAsiento</b>, <b>fila</b>, <u>idClase</u>, <u>idAvion</u>)
+UBICACIÓN  (<b>nroAsiento</b>, <b>fila</b>, <u>idClase</u>, <b><u>idAvion</u></b>)
 CLASE      (<b>idClase</b>, descClase)
 TARIFA     (<b><u>codAeptoOrigen</u></b>, <b><u>codAeptoDestino</u></b>, precioClaseTurista, <u>fechaDesde</u>, fechaHasta)
 PASAJE     (<b><u>tipoDoc</u></b>, <b><u>nroDoc</u></b>, <b><u>nroVuelo</u></b>, <u>nroAsiento</u>, <u>fila</u>)

--- a/_posts/2017-08-26-practica-mr.md
+++ b/_posts/2017-08-26-practica-mr.md
@@ -46,13 +46,13 @@ Tener en cuenta las siguientes pautas:
 
 <pre>
 PAIS           (<b>IdPais</b>​, Nombre)
-PARTICIPANTE   (<u><b>IdTipoDoc​</b></u>, <b>NúmeroDocumento​</b>, Nombre, Apellido, Dirección, Teléfono, <u>IdPais, IdHotel</u>, <u>NumeroSucursal</u>, TipoParticipante)
+PARTICIPANTE   (<u><b>IdTipoDoc​</b></u>, <b>NúmeroDocumento​</b>, Nombre, Apellido, Dirección, Teléfono, <u>IdPais</u>, <u>IdHotel</u>, <u>NumeroSucursal</u>, TipoParticipante)
 TIPO_DOCUMENTO (<b>IdTipoDoc​</b>, Descripción)
 JUGADOR        (<u><b>IdTipoDoc​</b></u>, <u><b>​NúmeroDocumento​</b></u>, Nivel)
 DISPUTA        (<u><b>IdTipoDoc​</b></u>, <u><b>​NúmeroDocumento​</b></u>, <u><b>​IdPartido​</b></u>, Color)
 ARBITRO        (<u><b>IdTipoDoc​</b></u>, <u><b>​NúmeroDocumento​</b></u>, Fecha_inicio_profesional)
 HOTEL          (<b>IdHotel​</b>, Razón Social, Cant_Sucursales)
-SALA           (<b>NúmSala​</b>, <u><b>NúmeroSucursal, IdHotel​</b></u>, Nombre, CantAsientos)
+SALA           (<b>NúmSala​</b>, <u><b>NúmeroSucursal</b></u>, <u><b>IdHotel​</b></u>, Nombre, CantAsientos)
 PARTIDO        (<b>IdPartido​</b>, Duración, Fecha, <u>IdTipoDocArbitro</u>, <u>númeroDocumentoArbitro</u>, <u>NúmeroSala</u>, <u>NúmeroSucursal</u>, <u>IdHotel</u>)
 JUGADA         (<b>NumeroJugada​</b>, <u><b>IdPartido​</b></u>, <u>IdTipoDoc</u>, <u>NúmeroDocumento</u>,
 Movimiento, Comentario)


### PR DESCRIPTION
Propongo algunos cambios:
1. Separar los campos en las definiciones de las tablas, para que en lugar de **_campo1, campo2_** sea siempre **_campo1_**, **_campo2_**
1. En el ejercicio 4, la definicion de la relacion Ubicacion, para mi idAvion deberia ser PK ademas de FK.
1. En el ejercicio 4, la definicion de la relacion Tarifa, para mi fechaDesde tiene que ser PK y no FK.